### PR TITLE
Restore the Autostart checkbox in the tray menu (fixes #158)

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -133,6 +133,7 @@ public class TrayApplicationContext : ApplicationContext
 
         ContextMenuStrip contextMenu = new ContextMenuStrip();
         contextMenu.ShowImageMargin = false;
+        contextMenu.ShowCheckMargin = true;
         contextMenu.Items.Add(_menuItemAutostart);
         contextMenu.Items.Add(new ToolStripSeparator());
         contextMenu.Items.Add(_menuItemStart);


### PR DESCRIPTION
I tried all combinations of ShowImageMargin and ShowCheckMargin to compare how they're rendered - see the screenshots below. The difference between enabling only the image margin (old behavior in 10.11.2) and enabling only the check margin (what I propose here) is _very_ subtle, but with the image margin, the checkbox is slightly higher (less centered) than when using the check margin.

Enabling just the check margin seems to give the nicest outcome (more centered checkmark), and also properly communicates the intent here (no images to show => disable image margin; want to show a check => enable check margin).

<table>
<tr>
 <td>
<img width="143" height="160" alt="image" src="https://github.com/user-attachments/assets/8a5d7631-976d-4ec6-858f-8dc0faa3b736" />
 <td>
<img width="143" height="160" alt="image" src="https://github.com/user-attachments/assets/0942f527-4b45-4651-94df-9623f2e693ff" />
 <td>
<img width="165" height="160" alt="image" src="https://github.com/user-attachments/assets/4c68962a-f902-4fff-8fd5-81d6ab49049e" />
<td>
<img width="118" height="160" alt="image" src="https://github.com/user-attachments/assets/c83d236b-2bd9-4b88-bb36-2650a0c0c8a6" />
<tr>
 <td>Old behavior in 10.11.2
 <td>Proposed fix
 <td>
 <td>Current behavior in 10.11.3
</table>

Enabling both margins is obviously undesirable; I just included that screenshot for curiosity's sake.